### PR TITLE
Update form controls

### DIFF
--- a/text/0000-semantic-test-selectors.md
+++ b/text/0000-semantic-test-selectors.md
@@ -163,6 +163,7 @@ A **button** is one of the following:
 - `input[type="reset"]`
 - `input[type="submit"]`
 - `[role="button"]`
+- `input[type="image"][alt]`
 
 An **input** is one of the following:
 
@@ -174,15 +175,15 @@ An **input** is one of the following:
 - `[role="textbox"]`
 - `[contenteditable="true"]`
 
-A **switch** is one of the following:
 
+A **switch** is one of the following:
 - `input[type="checkbox"]`
 - `input[type="radio"]`
 - `[role="checkbox"]`
 - `[role="option"]`
 - `[role="radio"]`
 
-A **form control** is an **input** or **switch**.
+A **form control** is an **input**, **switch**, **select**
 
 The **perceivable text** of a **link**, **button**, or other element may be
 found in any/all of the following locations **if-and-only-if the element is

--- a/text/0000-semantic-test-selectors.md
+++ b/text/0000-semantic-test-selectors.md
@@ -169,18 +169,20 @@ An **input** is one of the following:
 
 - `input`
 - `textarea`
-- `select`
 - `[role="slider"]`
 - `[role="spinbutton"]`
 - `[role="textbox"]`
 - `[contenteditable="true"]`
 
+A **select** is one of the following:
+
+- `select`
+- `[role="listbox"]`
 
 A **switch** is one of the following:
 - `input[type="checkbox"]`
 - `input[type="radio"]`
 - `[role="checkbox"]`
-- `[role="option"]`
 - `[role="radio"]`
 
 A **form control** is an **input**, **switch**, **select**


### PR DESCRIPTION
Added something that would be considered a button,

Option would not be used without a `select` or `role=listbox` and moved then to **select** section, since the behavior of selecting and filling in can overlap. for example power-select i can fill in a value, and then select `add tag value`.